### PR TITLE
Make test output neater

### DIFF
--- a/bin/fbcmt-compare-frog
+++ b/bin/fbcmt-compare-frog
@@ -67,4 +67,4 @@ import FBCModelTests.FROG
 @info "Initialization done, starting FROG comparison..." reports
 
 # run the FROG
-FROG.compare_reports(reports[1], reports[2]; absolute_tolerance, relative_tolerance)
+FROG.compare_reports_toplevel(reports[1], reports[2]; absolute_tolerance, relative_tolerance)

--- a/src/common.jl
+++ b/src/common.jl
@@ -50,3 +50,18 @@ Test.get_alignment(ts::QuietTestSet, depth = 0) = Test.get_alignment(ts.inner, d
 Test.filter_errors(ts::QuietTestSet) = Test.filter_errors(ts.inner)
 Test.get_test_counts(ts::QuietTestSet) = Test.get_test_counts(ts.inner)
 Test.print_counts(ts::QuietTestSet, args...) = Test.print_counts(ts.inner, args...)
+
+macro atest(ex, desc)
+    result = quote
+        try
+            $(Test.Returned)($(esc(ex)), nothing, $(QuoteNode(__source__)))
+        catch _e
+            _e isa InterruptException && rethrow()
+            $(Test.Threw)(_e, Base.current_exceptions(), $(QuoteNode(__source__)))
+        end
+    end
+    Base.remove_linenums!(result)
+    quote
+        $(Test.do_test)($result, $desc)
+    end
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -48,25 +48,15 @@ macro atest(ex, desc)
     end
     Base.remove_linenums!(result)
     quote
-        $(Test.do_test)($result, $desc)
+        $(Test.do_test)($result, $(esc(desc)))
     end
 end
 
-test_dicts_plain(match::Function, a::Dict, b::Dict) =
+test_dicts(match::Function, a::Dict, b::Dict) =
     for k in union(keys(a), keys(b))
         @atest haskey(a, k) && haskey(b, k) "$k is present"
         if haskey(a, k) && haskey(b, k)
             match(k, a[k], b[k])
-        end
-    end
-
-test_dicts(match::Function, a::Dict, b::Dict) =
-    for k in union(keys(a), keys(b))
-        @testset "$k" begin
-            @atest haskey(a, k) && haskey(b, k) "$k is present"
-            if haskey(a, k) && haskey(b, k)
-                match(k, a[k], b[k])
-            end
         end
     end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -13,3 +13,40 @@ test_dicts(match::Function, a::Dict, b::Dict) =
             end
         end
     end
+
+struct QuietTestSet <: Test.AbstractTestSet
+    inner::Test.DefaultTestSet
+    QuietTestSet(desc::AbstractString; kwargs...) =
+        new(Test.DefaultTestSet(desc; kwargs...))
+end
+
+Quiet(args...; kwargs...) = QuietTestSet(Test.DefaultTestSet(args...; kwargs...))
+
+function Test.record(ts::QuietTestSet, t::Union{Test.Result,Test.AbstractTestSet})
+    Test.record(ts.inner, t)
+end
+
+function Test.record(
+    ts::QuietTestSet,
+    t::Test.Fail;
+    print_result::Bool = Test.TESTSET_PRINT_ENABLE[],
+)
+    if print_result
+        print(ts.inner.description, ": ")
+        println()
+        if t.test_type !== :test_interrupted
+            println(t)
+        end
+    end
+    push!(ts.inner.results, t)
+    return t
+end
+
+Test.finish(ts::QuietTestSet; kwargs...) = Test.finish(ts.inner; kwargs...)
+Test.print_test_errors(ts::QuietTestSet) = Test.print_test_errors(ts.inner)
+Test.print_test_results(ts::QuietTestSet, depth_pad = 0) =
+    Test.print_test_results(ts.inner, depth_pad)
+Test.get_alignment(ts::QuietTestSet, depth = 0) = Test.get_alignment(ts.inner, depth)
+Test.filter_errors(ts::QuietTestSet) = Test.filter_errors(ts.inner)
+Test.get_test_counts(ts::QuietTestSet) = Test.get_test_counts(ts.inner)
+Test.print_counts(ts::QuietTestSet, args...) = Test.print_counts(ts.inner, args...)

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,19 +1,5 @@
 const Maybe{T} = Union{Nothing,T}
 
-gets(c::Dict, def, k, ks...) = haskey(c, k) ? gets(c[k], def, ks...) : def
-gets(c::Tuple, def, k, ks...) = k in 1:length(c) ? gets(c[k], def, ks...) : def
-gets(c, _) = c
-
-test_dicts(match::Function, a::Dict, b::Dict) =
-    for k in union(keys(a), keys(b))
-        @testset "$k" begin
-            @test haskey(a, k) && haskey(b, k)
-            if haskey(a, k) && haskey(b, k)
-                match(k, a[k], b[k])
-            end
-        end
-    end
-
 struct QuietTestSet <: Test.AbstractTestSet
     inner::Test.DefaultTestSet
     QuietTestSet(desc::AbstractString; kwargs...) =
@@ -65,3 +51,25 @@ macro atest(ex, desc)
         $(Test.do_test)($result, $desc)
     end
 end
+
+test_dicts_plain(match::Function, a::Dict, b::Dict) =
+    for k in union(keys(a), keys(b))
+        @atest haskey(a, k) && haskey(b, k) "$k is present"
+        if haskey(a, k) && haskey(b, k)
+            match(k, a[k], b[k])
+        end
+    end
+
+test_dicts(match::Function, a::Dict, b::Dict) =
+    for k in union(keys(a), keys(b))
+        @testset "$k" begin
+            @atest haskey(a, k) && haskey(b, k) "$k is present"
+            if haskey(a, k) && haskey(b, k)
+                match(k, a[k], b[k])
+            end
+        end
+    end
+
+gets(c::Dict, def, k, ks...) = haskey(c, k) ? gets(c[k], def, ks...) : def
+gets(c::Tuple, def, k, ks...) = k in 1:length(c) ? gets(c[k], def, ks...) : def
+gets(c, _) = c

--- a/src/frog.jl
+++ b/src/frog.jl
@@ -17,7 +17,7 @@ using JSON
 using SBML
 using Test
 
-using ..FBCModelTests: Maybe
+using ..FBCModelTests: Maybe, QuietTestSet
 
 include("frog/structs.jl")
 include("frog/report.jl")

--- a/src/frog/frontend.jl
+++ b/src/frog/frontend.jl
@@ -39,12 +39,22 @@ function compare_reports(report_dir_a::String, report_dir_b::String; kwargs...)
     a = ReportIO.load_report(report_dir_a)
     b = ReportIO.load_report(report_dir_b)
 
-    @testset "Comparing FROG reports in $report_dir_a and $report_dir_b" begin
-        @testset "Metadata" begin
-            ReportTests.test_metadata_compatibility(a.metadata, b.metadata)
-        end
-        @testset "Objectives and solution values" begin
-            ReportTests.test_report_compatibility(a.report, b.report; kwargs...)
-        end
+    @testset "Metadata" begin
+        ReportTests.test_metadata_compatibility(a.metadata, b.metadata)
+    end
+    @testset "Objectives and solution values" begin
+        ReportTests.test_report_compatibility(a.report, b.report; kwargs...)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Like [`compare_reports`](@ref), but with a specific testset settings that
+provide better user-facing reports.
+"""
+function compare_reports_toplevel(report_dir_a::String, report_dir_b::String; kwargs...)
+    @testset QuietTestSet "Comparison of FROG reports $report_dir_a and $report_dir_b" begin
+        compare_reports(report_dir_a, report_dir_b; kwargs...)
     end
 end

--- a/src/frog/report.jl
+++ b/src/frog/report.jl
@@ -8,7 +8,7 @@ module ReportGenerators
 
 using ..FROG: FROGReactionReport, FROGObjectiveReport, FROGMetadata, FROGReportData
 
-using ...FBCModelTests: FBCMT_VERSION, @atest
+using ...FBCModelTests: FBCMT_VERSION
 
 using COBREXA
 using JuMP
@@ -197,7 +197,7 @@ Function for testing the compatibility of FROG report data.
 module ReportTests
 
 using ..FROG: FROGReportData, FROGMetadata
-using ...FBCModelTests: test_dicts
+using ...FBCModelTests: test_dicts, @atest
 
 using Test, DocStringExtensions
 
@@ -223,12 +223,12 @@ function test_report_compatibility(
             (intol(a, min) || intol(a, max) || (min <= a && a <= max))
         )
 
-    @testset "Comparing objectives" begin
-        test_dicts(
-            (_, a, b) -> begin
+    test_dicts(
+        (objid, a, b) -> begin
+            @testset "Objective $objid" begin
                 @atest intol(a.optimum, b.optimum) "objective values are the same"
                 @testset "Reactions" begin
-                    test_dicts_plain(
+                    test_dicts(
                         (rid, a, b) -> begin
                             @atest intol(a.variability_min, b.variability_min) "lower variability bound of $rid matches"
                             @atest intol(a.variability_max, b.variability_max) "upper variability bound of $rid matches"
@@ -250,7 +250,7 @@ function test_report_compatibility(
                     )
                 end
                 @testset "Gene deletions" begin
-                    test_dicts_plain(
+                    test_dicts(
                         (gid, a, b) -> begin
                             @atest intol(a, b) "deletion of gene $gid gives the same objective value"
                         end,
@@ -258,11 +258,11 @@ function test_report_compatibility(
                         b.gene_deletions,
                     )
                 end
-            end,
-            a,
-            b,
-        )
-    end
+            end
+        end,
+        a,
+        b,
+    )
 end
 
 """


### PR DESCRIPTION
@stelmo  let's organize the julia Test workarounds/improvements here

we have:
- [x] a testset that isn't brutally verbose
- [x] it defaults sanely to the existing test sets
- [x] a `@test` macro that fails with a better error description than just the plain unsubstituted expression (I might just copy it from https://github.com/JuliaLang/julia/pull/49788 for now)